### PR TITLE
Multisig support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,10 +24,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "blake3"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
@@ -95,6 +120,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -174,6 +208,12 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cpufeatures"
@@ -687,6 +727,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +972,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 name = "xelis-he"
 version = "0.1.0"
 dependencies = [
+ "blake3",
  "bulletproofs",
  "bytemuck",
  "chacha20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ sha3 = "0.10.8"
 thiserror = "1.0.56"
 zeroize = "1.7.0"
 chacha20 = "0.9.1"
+blake3 = "1.5.4"
 
 [[bench]]
 name = "tx"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Support of following transactions types:
 - Burn: ability to burn a public amount of requested asset from an encrypted balance without revealing it.
 - Transfers: send to one or more destinations any asset / amount.
 - Smart Contract: ability to transfers plaintext amounts using confidentials assets and encrypted balances to a Smart Contract / Public account.
+- Multi-Sig: Secure a wallet behind more than one keypair by providing two ways: on-chain approvals, and off-chains approvals integrated in the TX directly.
 
 Support of Confidential Assets (spend any asset available, not just the "native coin").
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Support of following transactions types:
 - Burn: ability to burn a public amount of requested asset from an encrypted balance without revealing it.
 - Transfers: send to one or more destinations any asset / amount.
 - Smart Contract: ability to transfers plaintext amounts using confidentials assets and encrypted balances to a Smart Contract / Public account.
-- Multi-Sig: Secure a wallet behind more than one keypair by providing two ways: on-chain approvals, and off-chains approvals integrated in the TX directly.
+- Multi-Sig: Secure a wallet behind more than one keypair by providing off-chain approvals integrated in the TX directly.
 
 Support of Confidential Assets (spend any asset available, not just the "native coin").
 

--- a/benches/tx.rs
+++ b/benches/tx.rs
@@ -20,6 +20,7 @@ fn n_tx_bench(c: &mut Criterion, n_transfers: usize) {
                 (alice.keypair.pubkey().compress(), alice.clone()),
             ]
             .into(),
+            multisig_accounts: Default::default(),
         };
 
         let bob = bob.keypair.pubkey().compress();
@@ -133,6 +134,7 @@ fn batching_bench_util(c: &mut Criterion, batch_size: usize) {
                 (alice.keypair.pubkey().compress(), alice.clone()),
             ]
             .into(),
+            multisig_accounts: Default::default(),
         };
         let mut prover_ledger = ledger.clone();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,10 +181,10 @@ pub mod mock {
         fn set_multisig_for_account(
             &mut self,
             account: &CompressedPubkey,
-            signers: Vec<CompressedPubkey>,
+            signers: &Vec<CompressedPubkey>,
             threshold: u8,
         ) -> Result<(), Self::Error> {
-            self.multisig_accounts.insert(account.clone(), (signers, threshold));
+            self.multisig_accounts.insert(account.clone(), (signers.clone(), threshold));
             Ok(())
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,6 +362,130 @@ pub mod tests {
     }
 
     #[test]
+    fn test_multisig_threshold_2() {
+        let alice = Account::new([(Hash([0; 32]), 100)]);
+        let bob = Account::new([(Hash([0; 32]), 0)]);
+        let charlie = Account::new([(Hash([0; 32]), 0)]);
+        let dave = Account::new([(Hash([0; 32]), 0)]);
+
+        let tx = {
+            let builder = TransactionBuilder {
+                version: 1,
+                source: alice.keypair.pubkey().compress(),
+                data: TransactionTypeBuilder::Transfers(vec![TransferBuilder {
+                    dest_pubkey: bob.keypair.pubkey().compress(),
+                    amount: 10,
+                    asset: Hash([0; 32]),
+                    extra_data: Default::default(),
+                }]),
+                fee: 1,
+                nonce: 0,
+            };
+
+            assert_eq!(11, builder.get_transaction_cost(&Hash([0; 32])));
+            assert_eq!(1, builder.used_assets().len());
+
+            let mut unsigned = builder
+                .build_unsigned(
+                    &mut GenerationBalance {
+                        balances: [(Hash([0; 32]), 100)].into(),
+                        account: alice.clone(),
+                    },
+                    &alice.keypair,
+                )
+                .unwrap();
+
+            let hash = unsigned.hash();
+            let signature1 = charlie.keypair.sign(&hash.0);
+            let signature2 = dave.keypair.sign(&hash.0);
+            unsigned.set_multisig(vec![(0, signature1), (1, signature2)]);
+            unsigned.sign(&alice.keypair)
+        };
+
+        let mut ledger = Ledger {
+            accounts: [
+                (alice.keypair.pubkey().compress(), alice.clone()),
+                (bob.keypair.pubkey().compress(), bob.clone()),
+                (charlie.keypair.pubkey().compress(), charlie.clone()),
+                (dave.keypair.pubkey().compress(), dave.clone()),
+            ].into(),
+            multisig_accounts: Default::default(),
+        };
+
+        // Add multisig
+        ledger.set_multisig_for_account(
+            &alice.keypair.pubkey().compress(),
+            &vec![charlie.keypair.pubkey().compress(), dave.keypair.pubkey().compress()],
+            2,
+        )
+        .unwrap();
+
+        Transaction::verify(&tx, &mut ledger).unwrap();
+    }
+
+    #[test]
+    fn test_multisig_threshold_one_on_two_signers() {
+        let alice = Account::new([(Hash([0; 32]), 100)]);
+        let bob = Account::new([(Hash([0; 32]), 0)]);
+        let charlie = Account::new([(Hash([0; 32]), 0)]);
+        let dave = Account::new([(Hash([0; 32]), 0)]);
+
+        let tx = {
+            let builder = TransactionBuilder {
+                version: 1,
+                source: alice.keypair.pubkey().compress(),
+                data: TransactionTypeBuilder::Transfers(vec![TransferBuilder {
+                    dest_pubkey: bob.keypair.pubkey().compress(),
+                    amount: 10,
+                    asset: Hash([0; 32]),
+                    extra_data: Default::default(),
+                }]),
+                fee: 1,
+                nonce: 0,
+            };
+
+            assert_eq!(11, builder.get_transaction_cost(&Hash([0; 32])));
+            assert_eq!(1, builder.used_assets().len());
+
+            let mut unsigned = builder
+                .build_unsigned(
+                    &mut GenerationBalance {
+                        balances: [(Hash([0; 32]), 100)].into(),
+                        account: alice.clone(),
+                    },
+                    &alice.keypair,
+                )
+                .unwrap();
+
+            let hash = unsigned.hash();
+            let signature1 = dave.keypair.sign(&hash.0);
+            unsigned.set_multisig(vec![(1, signature1)]);
+            unsigned.sign(&alice.keypair)
+        };
+
+        let mut ledger = Ledger {
+            accounts: [
+                (alice.keypair.pubkey().compress(), alice.clone()),
+                (bob.keypair.pubkey().compress(), bob.clone()),
+                (charlie.keypair.pubkey().compress(), charlie.clone()),
+                (dave.keypair.pubkey().compress(), dave.clone()),
+            ].into(),
+            multisig_accounts: Default::default(),
+        };
+
+        // Add multisig
+        // One of the two signers is enough
+        ledger.set_multisig_for_account(
+            &alice.keypair.pubkey().compress(),
+            &vec![charlie.keypair.pubkey().compress(), dave.keypair.pubkey().compress()],
+            1,
+        )
+        .unwrap();
+
+        Transaction::verify(&tx, &mut ledger).unwrap();
+    }
+
+    #[test]
     fn test_burn() {
         let alice = Account::new([(Hash([0; 32]), 100)]);
         let tx = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,65 @@ pub mod tests {
     }
 
     #[test]
+    fn test_multisig() {
+        let alice = Account::new([(Hash([0; 32]), 100)]);
+        let bob = Account::new([(Hash([0; 32]), 0)]);
+        let charlie = Account::new([(Hash([0; 32]), 0)]);
+
+        let tx = {
+            let builder = TransactionBuilder {
+                version: 1,
+                source: alice.keypair.pubkey().compress(),
+                data: TransactionTypeBuilder::Transfers(vec![TransferBuilder {
+                    dest_pubkey: bob.keypair.pubkey().compress(),
+                    amount: 10,
+                    asset: Hash([0; 32]),
+                    extra_data: Default::default(),
+                }]),
+                fee: 1,
+                nonce: 0,
+            };
+
+            assert_eq!(11, builder.get_transaction_cost(&Hash([0; 32])));
+            assert_eq!(1, builder.used_assets().len());
+
+            let mut unsigned = builder
+                .build_unsigned(
+                    &mut GenerationBalance {
+                        balances: [(Hash([0; 32]), 100)].into(),
+                        account: alice.clone(),
+                    },
+                    &alice.keypair,
+                )
+                .unwrap();
+
+            let hash = unsigned.hash();
+            let signature = charlie.keypair.sign(&hash.0);
+            unsigned.set_multisig(vec![(0, signature)]);
+            unsigned.sign(&alice.keypair)
+        };
+
+        let mut ledger = Ledger {
+            accounts: [
+                (alice.keypair.pubkey().compress(), alice.clone()),
+                (bob.keypair.pubkey().compress(), bob.clone()),
+                (charlie.keypair.pubkey().compress(), charlie.clone()),
+            ].into(),
+            multisig_accounts: Default::default(),
+        };
+
+        // Add multisig
+        ledger.set_multisig_for_account(
+            &alice.keypair.pubkey().compress(),
+            &vec![charlie.keypair.pubkey().compress()],
+            1,
+        )
+        .unwrap();
+
+        Transaction::verify(&tx, &mut ledger).unwrap();
+    }
+
+    #[test]
     fn test_burn() {
         let alice = Account::new([(Hash([0; 32]), 100)]);
         let tx = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ pub mod mock {
     #[derive(Debug, Clone)]
     pub struct Ledger {
         pub accounts: HashMap<CompressedPubkey, Account>,
+        pub multisig_accounts: HashMap<CompressedPubkey, (Vec<CompressedPubkey>, u8)>,
     }
 
     impl Ledger {
@@ -175,6 +176,23 @@ pub mod mock {
             _ct: ElGamalCiphertext,
         ) -> Result<(), Self::Error> {
             Ok(())
+        }
+
+        fn set_multisig_for_account(
+            &mut self,
+            account: &CompressedPubkey,
+            signers: Vec<CompressedPubkey>,
+            threshold: u8,
+        ) -> Result<(), Self::Error> {
+            self.multisig_accounts.insert(account.clone(), (signers, threshold));
+            Ok(())
+        }
+
+        fn get_multisig_for_account(
+                &self,
+                account: &CompressedPubkey,
+            ) -> Result<Option<(Vec<CompressedPubkey>, u8)>, Self::Error> {
+            Ok(self.multisig_accounts.get(account).cloned())
         }
     }
 
@@ -259,7 +277,8 @@ pub mod tests {
         };
 
         let mut ledger = Ledger {
-            accounts: [(alice.keypair.pubkey().compress(), alice.clone())].into()
+            accounts: [(alice.keypair.pubkey().compress(), alice.clone())].into(),
+            multisig_accounts: Default::default(),
         };
 
         Transaction::verify_batch(&vec![tx], &mut ledger).unwrap();
@@ -301,7 +320,8 @@ pub mod tests {
         };
 
         let mut ledger = Ledger {
-            accounts: [(alice.keypair.pubkey().compress(), alice.clone())].into()
+            accounts: [(alice.keypair.pubkey().compress(), alice.clone())].into(),
+            multisig_accounts: Default::default(),
         };
 
         Transaction::verify_batch(&vec![tx], &mut ledger).unwrap();
@@ -345,7 +365,8 @@ pub mod tests {
         };
 
         let ledger = Ledger {
-            accounts: [(alice.keypair.pubkey().compress(), alice.clone())].into()
+            accounts: [(alice.keypair.pubkey().compress(), alice.clone())].into(),
+            multisig_accounts: Default::default(),
         };
 
         assert!(Transaction::verify(&tx, &mut ledger.clone()).is_ok());
@@ -397,7 +418,8 @@ pub mod tests {
         };
 
         let ledger = Ledger {
-            accounts: [(alice.keypair.pubkey().compress(), alice.clone())].into()
+            accounts: [(alice.keypair.pubkey().compress(), alice.clone())].into(),
+            multisig_accounts: Default::default(),
         };
 
         // Tx without change is valid
@@ -455,6 +477,7 @@ pub mod tests {
                 (eve.keypair.pubkey().compress(), eve.clone()),
             ]
             .into(),
+            multisig_accounts: Default::default(),
         };
 
         let bob = bob.keypair.pubkey().compress();
@@ -572,6 +595,7 @@ pub mod tests {
                 (alice.keypair.pubkey().compress(), alice.clone()),
             ]
             .into(),
+            multisig_accounts: Default::default(),
         };
 
         let bob_pk = bob.keypair.pubkey().compress();
@@ -651,6 +675,7 @@ pub mod tests {
                 (alice.keypair.pubkey().compress(), alice.clone()),
             ]
             .into(),
+            multisig_accounts: Default::default(),
         };
 
         let bob = bob.keypair.pubkey().compress();

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -30,6 +30,7 @@ pub trait ProtocolTranscript {
     fn new_commitment_eq_proof_domain_separator(&mut self);
     fn transfer_proof_domain_separator(&mut self);
     fn burn_proof_domain_separator(&mut self);
+    fn multisig_proof_domain_separator(&mut self);
     fn ciphertext_validity_proof_domain_separator(&mut self);
 }
 
@@ -94,6 +95,10 @@ impl ProtocolTranscript for Transcript {
 
     fn burn_proof_domain_separator(&mut self) {
         self.append_message(b"dom-sep", b"burn-proof");
+    }
+
+    fn multisig_proof_domain_separator(&mut self) {
+        self.append_message(b"dom-sep", b"multisig-proof");
     }
 
     fn equality_proof_domain_separator(&mut self) {

--- a/src/tx/builder.rs
+++ b/src/tx/builder.rs
@@ -485,7 +485,7 @@ impl TransactionBuilder {
             }),
             TransactionTypeBuilder::DeployContract(c) => TransactionType::DeployContract(c),
             TransactionTypeBuilder::MultiSig { signers, threshold } => {
-                if threshold == 0 || threshold as usize > signers.len() {
+                if threshold as usize > signers.len() || (!signers.is_empty() && threshold == 0) {
                     return Err(GenerationError::Proof(ProofGenerationError::Format));
                 }
 

--- a/src/tx/builder.rs
+++ b/src/tx/builder.rs
@@ -492,6 +492,11 @@ impl TransactionBuilder {
                 transcript.multisig_proof_domain_separator();
                 transcript.append_u64(b"threshold", threshold as u64);
                 for (i, signer) in signers.iter().enumerate() {
+                    // Signer cannot be the source
+                    if *signer == self.source {
+                        return Err(GenerationError::Proof(ProofGenerationError::Format));
+                    }
+
                     if signers.iter().enumerate().any(|(j, s)| i != j && s == signer) {
                         return Err(GenerationError::Proof(ProofGenerationError::Format));
                     }

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -14,6 +14,8 @@ use crate::{
     ExtraDataDecryptionError, Hash, Role, Signature,
 };
 
+pub type MultiSig = Vec<(u8, Signature)>;
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Transfer {
     pub asset: Hash,
@@ -107,14 +109,12 @@ pub struct Transaction {
     pub(crate) new_source_commitments: Vec<NewSourceCommitment>,
     /// The range proof is aggregated across all transfers and across all assets.
     pub(crate) range_proof: RangeProof,
-    /// Signature of the TX by the source.
-    pub(crate) signature: Signature,
     /// Multisig signatures.
     /// Useful for directly accepted multisig transactions without any on-chain interaction.
     /// The first element of the tuple is the index of the signer
-    /// This part is alterable by anyone has it is not included in transcript or source signature.
-    /// TODO: should we include it in the source signature instead ?
-    pub(crate) multisig: Option<Vec<(u8, Signature)>>,
+    pub(crate) multisig: Option<MultiSig>,
+    /// Signature of the TX by the source.
+    pub(crate) signature: Signature,
 }
 
 impl Transaction {
@@ -144,9 +144,5 @@ impl Transaction {
 
     pub fn consume(self) -> (CompressedPubkey, TransactionType) {
         (self.source, self.data)
-    }
-
-    pub fn add_signature(&mut self, index: u8, signature: Signature) {
-        self.multisig.get_or_insert_with(Vec::new).push((index, signature));
     }
 }

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -88,7 +88,8 @@ pub enum TransactionType {
     CallContract(SmartContractCall),
     // represent the code to deploy
     DeployContract(String),
-    Multisig { signers: Vec<CompressedPubkey>, threshold: u8 },
+    // Configure the current account owner as a multisig account
+    MultiSig { signers: Vec<CompressedPubkey>, threshold: u8 },
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -396,7 +396,7 @@ impl Transaction {
                 transcript.append_hash(b"asset", asset);
                 transcript.append_u64(b"amount", *amount);
             },
-            TransactionType::Multisig { signers, threshold } => {
+            TransactionType::MultiSig { signers, threshold } => {
                 if *threshold == 0 || *threshold as usize > signers.len() {
                     return Err(VerificationError::Proof(ProofVerificationError::Format));
                 }
@@ -593,7 +593,7 @@ impl Transaction {
                     )?;
                 }
             },
-            TransactionType::Multisig { signers, threshold } => {
+            TransactionType::MultiSig { signers, threshold } => {
                 state.set_multisig_for_account(&self.source, signers, *threshold)?;
             },
             _ => (),
@@ -644,7 +644,7 @@ impl Transaction {
             TransactionType::DeployContract(contract) => {
                 bytes.extend_from_slice(&contract.as_bytes());
             },
-            TransactionType::Multisig { signers, threshold } => {
+            TransactionType::MultiSig { signers, threshold } => {
                 bytes.extend_from_slice(&threshold.to_be_bytes());
                 for signer in signers {
                     bytes.extend_from_slice(&signer.0);

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -280,6 +280,9 @@ impl Transaction {
                         }
                     }
                 }
+            } else {
+                // If we have a multisig in the state, but not in the transaction, it's invalid
+                return Err(VerificationError::Proof(ProofVerificationError::Format));
             }
         } else if self.get_multisisg().is_some() {
             // If we have a multisig in the transaction, but not in the state, it's invalid

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -401,6 +401,18 @@ impl Transaction {
                     return Err(VerificationError::Proof(ProofVerificationError::Format));
                 }
 
+                // All signers must be unique
+                if signers.iter().enumerate().any(|(i, signer)| {
+                    signers.iter().enumerate().any(|(j, signer2)| i != j && signer == signer2)
+                }) {
+                    return Err(VerificationError::Proof(ProofVerificationError::Format));
+                }
+
+                // Source cannot be part of the multisig
+                if signers.iter().any(|signer| signer == &self.source) {
+                    return Err(VerificationError::Proof(ProofVerificationError::Format));
+                }
+
                 transcript.multisig_proof_domain_separator();
                 transcript.append_u64(b"threshold", *threshold as u64);
                 for signer in signers {

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -258,7 +258,8 @@ impl Transaction {
         // Verify the incorporated multisig signatures
         if let Some((signers, threshold)) = state.get_multisig_for_account(&self.source).map_err(VerificationError::State)? {
             if let Some(signatures) = self.get_multisisg() {
-                if signatures.len() < threshold as usize {
+                // The multisig must have the exact same signers count as threshold
+                if signatures.len() != threshold as usize {
                     return Err(VerificationError::Proof(ProofVerificationError::Format));
                 }
 

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -259,7 +259,7 @@ impl Transaction {
         if let Some((signers, threshold)) = state.get_multisig_for_account(&self.source).map_err(VerificationError::State)? {
             if let Some(signatures) = self.get_multisisg() {
                 // The multisig must have the exact same signers count as threshold
-                if signatures.len() != threshold as usize {
+                if signatures.is_empty() || signatures.len() != threshold as usize {
                     return Err(VerificationError::Proof(ProofVerificationError::Format));
                 }
 
@@ -397,7 +397,9 @@ impl Transaction {
                 transcript.append_u64(b"amount", *amount);
             },
             TransactionType::MultiSig { signers, threshold } => {
-                if *threshold == 0 || *threshold as usize > signers.len() {
+                // Threshold must be less or equal than the number of signers
+                // It can only be zero if there are no signers
+                if *threshold as usize > signers.len() || (!signers.is_empty() && *threshold == 0) {
                     return Err(VerificationError::Proof(ProofVerificationError::Format));
                 }
 


### PR DESCRIPTION
MultiSig (multi signature) is the requirement of a transaction to have more than one signature on the TX to be executed.

It can have a configured threshold, and signers list directly on-chain, with the ability to be updated at any time based following the multisig rules.

- Support up to 255 signers
- A threshold between 1 and signers count.
- Reconfigurable
- Source cannot be part of the multisig

If an account has a multisig configured, all following TXs must confirm with the defined rules.
A account can be removed from multisig feature by doing a setup with threshold set to 0 and no signers.
